### PR TITLE
Fix the static file backend problem

### DIFF
--- a/verynginx/lua_script/module/backend_static.lua
+++ b/verynginx/lua_script/module/backend_static.lua
@@ -20,7 +20,7 @@ function _M.filter()
         local enable = rule['enable']
         local matcher = matcher_list[ rule['matcher'] ] 
         if enable == true and request_tester.test( matcher ) == true then
-            ngx.var.vn_static_root = '/tmp'
+            ngx.var.vn_static_root = rule['root']
             ngx.exec('@vn_static') -- will jump out at the exec, so the return not run in fact
             return
         end


### PR DESCRIPTION
配置了一条规则对应了一个Backend，使用的是static file
百思不得其解为什么始终无法正常使用，看了看错误日志发现无论我配置的ROOT是什么，nginx访问的始终是`/tmp`这个目录
因此我修改了这个地方，改成了`rule['root']`
这样，问题解决～