### PR TITLE
Enhance python 2.6.x compatibility

### DIFF
--- a/install.py
+++ b/install.py
@@ -95,7 +95,7 @@ def exec_sys_cmd(cmd, accept_failed = False):
             return False
 
 def common_input( s ):
-    if sys.version_info.major == 3:
+    if sys.version_info[0] == 3:
         return input( s )
     else:
         return raw_input( s )


### PR DESCRIPTION
Named component attributes was added since python 2.7, python 2.6.x  don't have it.

> sys.version_info
> 
> A tuple containing the five components of the version number: major, minor, micro, releaselevel, and serial. All values except releaselevel are integers; the release level is 'alpha', 'beta', 'candidate', or 'final'. The version_info value corresponding to the Python version 2.0 is (2, 0, 0, 'final', 0). The components can also be accessed by name, so **sys.version_info[0] is equivalent to sys.version_info.major** and so on.
> 
> **Changed in version 2.7: Added named component attributes**

https://docs.python.org/2/library/sys.html

ISSUE: https://github.com/alexazhou/VeryNginx/issues/139