### PR TITLE
fix possible nil concatenation with string

### DIFF
--- a/verynginx/lua_script/module/summary.lua
+++ b/verynginx/lua_script/module/summary.lua
@@ -90,7 +90,7 @@ function _M.log()
         if with_host_info then
             uri = ngx.var.host..uri
         end
-        key_status = KEY_URI_STATUS..uri.."_"..status_code
+        key_status = KEY_URI_STATUS..(uri or '').."_"..status_code
         key_size = KEY_URI_SIZE..uri
         key_time = KEY_URI_TIME..uri
         key_count = KEY_URI_COUNT..uri


### PR DESCRIPTION
Attaching log:

```
2017/04/17 09:17:50 [error] 5536#0: *35204 failed to run log_by_lua*: /opt/verynginx/verynginx/lua_script/module/summary.lua:93: attempt to concatenate local 'uri' (a nil val
ue)
stack traceback:
        /opt/verynginx/verynginx/lua_script/module/summary.lua:93: in function 'log'
        /opt/verynginx/verynginx/lua_script/on_log.lua:5: in function </opt/verynginx/verynginx/lua_script/on_log.lua:1> while logging request, client: 191.9.2.97, server:
 crms
```