### PR TITLE
添加一个异常处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.swo
 *.swn
 *.swm
+.idea/
 __pycache__

--- a/verynginx/lua_script/module/request_tester.lua
+++ b/verynginx/lua_script/module/request_tester.lua
@@ -22,7 +22,7 @@ function _M.test( matcher )
             end
         elseif tester[name] == nil then
             return false
-		end
+	    end
 	end
 
 	return true

--- a/verynginx/lua_script/module/request_tester.lua
+++ b/verynginx/lua_script/module/request_tester.lua
@@ -19,7 +19,9 @@ function _M.test( matcher )
         if tester[name] ~= nil then
             if tester[name]( v ) ~= true then
                 return false
-			end
+            end
+        elseif tester[name] == nil then
+            return fase
 		end
 	end
 
@@ -52,10 +54,6 @@ function _M.test_var( match_operator, match_value, target_var )
             return true
         end
     elseif match_operator == '!Exist' then
-        if target_var == nil then
-            return true
-        end
-    elseif match_operator == '!' then
         if target_var == nil then
             return true
         end

--- a/verynginx/lua_script/module/request_tester.lua
+++ b/verynginx/lua_script/module/request_tester.lua
@@ -21,7 +21,7 @@ function _M.test( matcher )
                 return false
             end
         elseif tester[name] == nil then
-            return fase
+            return false
 		end
 	end
 


### PR DESCRIPTION

改了两处。

### 异常处理

当一个规则如`"URIXXX": { "value": "\\.(git|svn)", "operator": "≈" }`时，由于没有对URIXXX的处理，所以永远都会return true，所以添加了一个对这个场景的异常处理。

当然，如果通过dashboard不会存在这个问题，不过我最近在使用的时候，改了dashboard，升级后遇到了这个bug，所以提交了这个PR。

### `!`操作符

还有一个问题是，操作符`!`感叹号，根本用不到这个操作符，但是代码里还有，所以删除了该段代码。