### PR TITLE
Add cache-control and setting nocache for js verify page.

### DIFF
--- a/verynginx/lua_script/module/browser_verify.lua
+++ b/verynginx/lua_script/module/browser_verify.lua
@@ -82,6 +82,8 @@ function _M.verify_javascript()
     
     ngx.header.content_type = "text/html"
     ngx.header['cache-control'] = "no-cache, no-store, must-revalidate"
+    ngx.header['pragma'] = "no-cache"
+    ngx.header['expires'] = "0"
     ngx.header.charset = "utf-8"
     ngx.say( html )
     

--- a/verynginx/lua_script/module/browser_verify.lua
+++ b/verynginx/lua_script/module/browser_verify.lua
@@ -81,6 +81,7 @@ function _M.verify_javascript()
     html = util.string_replace( html,'INFOURI',redirect_to, 1 )
     
     ngx.header.content_type = "text/html"
+    ngx.header['cache-control'] = "no-cache, no-store, must-revalidate"
     ngx.header.charset = "utf-8"
     ngx.say( html )
     

--- a/verynginx/support/verify_javascript.html
+++ b/verynginx/support/verify_javascript.html
@@ -2,6 +2,9 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+        <meta http-equiv="Pragma" content="no-cache">
+        <meta http-equiv="Expires" content="0">
         <script type="text/javascript">
             var data = {
                 'cookie' : "INFOCOOKIE",


### PR DESCRIPTION
Add cache-control and setting nocache for js verify page.

因JS驗證頁面在某些極端情況下會被例如CDN之類的邊緣節點存儲快取。