### PR TITLE
Set configs folder's permission to 777 in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /code
 COPY ./ /code/
 WORKDIR /code
 RUN groupadd -r nginx && useradd -r -g nginx nginx
-RUN python install.py install
+RUN python install.py install && chmod 777 /opt/verynginx/verynginx/configs
 
 EXPOSE 80
 


### PR DESCRIPTION
Set configs folder's permission to 777 in the Dockerfile so that when run verynginx instance in a docker container, saving config works w/o manual permission change.

Without this `chmod`, we can't save config because verynginx doesn't have permission to the 'configs' folder, and will complain 'open file fail'.